### PR TITLE
adds __restore__ method to revert object back to original state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ assert.equal(
 ) // lookup works \o/
 ```
 
+## API
+
+### __restore__
+
+Put the object back into its initial state.
+
+```js
+var o = anyPath({
+  '.\\foo\\bar\\README.md': {name: 'README.md'}
+})
+o.__restore__().should.deep.equal({
+  '.\\foo\\bar\\README.md': {name: 'README.md'}
+})
+```
+
 ## License
 
 ISC

--- a/index.js
+++ b/index.js
@@ -8,16 +8,6 @@ function AnyPath (obj) {
   return obj
 }
 
-AnyPath.restore = function (obj) {
-  for (var prop in obj) {
-    if (hasOwnProperty.call(obj, prop)) {
-      if (obj.__lookupGetter__(prop)) delete obj[prop]
-    }
-  }
-
-  return obj
-}
-
 function setupHooks (prop, obj, value) {
   var paths = allPaths(prop.split(/[\\/]/g))
   var getter = function () {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = function (obj) {
+function AnyPath (obj) {
   for (var prop in obj) {
     if (hasOwnProperty.call(obj, prop)) {
       setupHooks(prop, obj, obj[prop])
@@ -8,16 +8,43 @@ module.exports = function (obj) {
   return obj
 }
 
+AnyPath.restore = function (obj) {
+  for (var prop in obj) {
+    if (hasOwnProperty.call(obj, prop)) {
+      if (obj.__lookupGetter__(prop)) delete obj[prop]
+    }
+  }
+
+  return obj
+}
+
 function setupHooks (prop, obj, value) {
   var paths = allPaths(prop.split(/[\\/]/g))
+  var getter = function () {
+    return obj[prop]
+  }
 
+  // put the object back into its initial state.
+  obj.__restore__ = function () {
+    for (var prop in obj) {
+      if (hasOwnProperty.call(obj, prop)) {
+        if (obj.__lookupGetter__(prop) === getter) delete obj[prop]
+      }
+    }
+    delete obj.__restore__
+
+    return obj
+  }
+
+  // expand the object to have all possible paths.
   paths.forEach(function (path) {
-    obj.__defineGetter__(path, function () {
-      return value
-    })
-    obj.__defineSetter__(path, function (newValue) {
-      value = newValue
-    })
+    if (path !== prop) {
+      obj.__defineGetter__(path, getter)
+
+      obj.__defineSetter__(path, function (newValue) {
+        obj[prop] = newValue
+      })
+    }
   })
 }
 
@@ -39,3 +66,5 @@ function allPaths (splitPath, partialPath, finalPaths, i) {
 
   return finalPaths
 }
+
+module.exports = AnyPath

--- a/test.js
+++ b/test.js
@@ -65,4 +65,16 @@ describe('any-test', function () {
     o['.\\foo\\bar\\README.md'].name.should.equal('package.json')
     return done()
   })
+
+  describe('restore', function () {
+    it('returns object back to its initial state', function (done) {
+      var o = anyPath({
+        '.\\foo\\bar\\README.md': {name: 'README.md'}
+      })
+      o.__restore__().should.deep.equal({
+        '.\\foo\\bar\\README.md': {name: 'README.md'}
+      })
+      return done()
+    })
+  })
 })


### PR DESCRIPTION
You can now call `__restore__()` on an object that has been modified with `any-path`, to put it back into its original state.
